### PR TITLE
Allow GoldenCrates keys to be used

### DIFF
--- a/src/main/java/su/nightexpress/excellentcrates/Keys.java
+++ b/src/main/java/su/nightexpress/excellentcrates/Keys.java
@@ -6,5 +6,6 @@ public class Keys {
 
     public static final NamespacedKey CRATE_ID     = new NamespacedKey(ExcellentCratesAPI.PLUGIN, "crate.id");
     public static final NamespacedKey CRATE_KEY_ID = new NamespacedKey(ExcellentCratesAPI.PLUGIN, "crate_key.id");
+    public static final NamespacedKey OLD_CRATES_KEY_ID = new NamespacedKey("goldencrates", "gcrates_key");
 
 }

--- a/src/main/java/su/nightexpress/excellentcrates/key/KeyManager.java
+++ b/src/main/java/su/nightexpress/excellentcrates/key/KeyManager.java
@@ -112,6 +112,9 @@ public class KeyManager extends AbstractManager<ExcellentCrates> {
     @Nullable
     public ICrateKey getKeyByItem(@NotNull ItemStack item) {
         String id = PDCUtil.getStringData(item, Keys.CRATE_KEY_ID);
+        if (id == null) {
+            id = PDCUtil.getStringData(item, Keys.OLD_CRATES_KEY_ID);
+        }
         return id == null ? null : this.getKeyById(id);
     }
 


### PR DESCRIPTION
This allows old GoldenCrates keys to be used on migrated crates.