### PR TITLE
Create permission for key giveall inclusion

### DIFF
--- a/src/main/java/su/nightexpress/excellentcrates/command/key/GiveAllCommand.java
+++ b/src/main/java/su/nightexpress/excellentcrates/command/key/GiveAllCommand.java
@@ -16,6 +16,7 @@ import su.nightexpress.nightcore.command.impl.AbstractCommand;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 class GiveAllCommand extends AbstractCommand<CratesPlugin> {
 
@@ -54,7 +55,9 @@ class GiveAllCommand extends AbstractCommand<CratesPlugin> {
         int amount = Math.abs(result.getInt(3, 1));
         if (amount == 0) return;
 
-        Collection<? extends Player> players = this.plugin.getServer().getOnlinePlayers();
+        Collection<? extends Player> players = this.plugin.getServer().getOnlinePlayers().stream()
+                .filter(p -> p.hasPermission(Perms.INCLUDE_KEY_GIVEALL))
+                .collect(Collectors.toSet());
         boolean silent = result.hasFlag(CommandFlags.SILENT);
 
         players.forEach(player -> {

--- a/src/main/java/su/nightexpress/excellentcrates/config/Perms.java
+++ b/src/main/java/su/nightexpress/excellentcrates/config/Perms.java
@@ -19,6 +19,8 @@ public class Perms {
 
     public static final UniPermission MASS_OPEN = new UniPermission(PREFIX + "massopen", "Allows to use mass open feature.", TRUE);
 
+    public static final UniPermission INCLUDE_KEY_GIVEALL = new UniPermission(PREFIX + "include.giveall", "Includes the player in the crate key giveall command.", TRUE);
+
     public static final UniPermission COMMAND_RELOAD             = new UniPermission(PREFIX_COMMAND + "reload", "Access to the '/crate reload' sub-command.");
     public static final UniPermission COMMAND_EDITOR             = new UniPermission(PREFIX_COMMAND + "editor", "Access to the '/crate editor' sub-command.");
     public static final UniPermission COMMAND_DROP               = new UniPermission(PREFIX_COMMAND + "drop", "Access to the '/crate drop' sub-command.");
@@ -45,7 +47,7 @@ public class Perms {
     public static final UniPermission BYPASS_REWARD_LIMIT_COOLDOWN = new UniPermission(PREFIX_BYPASS + "reward.limit.cooldown", "Bypasses reward's win limit cooldown.");
 
     static {
-        PLUGIN.addChildren(COMMAND, BYPASS, MASS_OPEN);
+        PLUGIN.addChildren(COMMAND, BYPASS, MASS_OPEN, INCLUDE_KEY_GIVEALL);
 
         COMMAND.addChildren(
             COMMAND_RELOAD,


### PR DESCRIPTION
This adds a (default true) permission for the `/crate key giveall` command, which allows server owners to exclude certain players (namely alt accounts) from getting crate keys via the command.