### PR TITLE
Hidden Rewards for Selectable

### DIFF
--- a/ExcellentCrates.iml
+++ b/ExcellentCrates.iml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="FacetManager">
+    <facet type="minecraft" name="Minecraft">
+      <configuration>
+        <autoDetectTypes>
+          <platformType>SPIGOT</platformType>
+          <platformType>ADVENTURE</platformType>
+        </autoDetectTypes>
+        <projectReimportVersion>1</projectReimportVersion>
+      </configuration>
+    </facet>
+  </component>
+</module>

--- a/README.md
+++ b/README.md
@@ -65,5 +65,9 @@
 - [Documentation](https://nightexpressdev.com/excellentcrates/)
 - [Developer API](https://nightexpressdev.com/excellentcrates/developer-api/)
 
+# Change Log:
+- Added support for `RandomizeSlots: true` variable for Reward in selectable opening animations _ONLY_. This will randomize reward slots when opened to allow hidden rewards.
+- Added support for `Material: minecraft:{material}` variable for Reward in selectable opening animations _ONLY_. Overrides the item shown in the GUI for the reward.
+
 # Donate
 If you like my work or enjoy using my plugins, feel free to [Buy me a coffee](https://ko-fi.com/nightexpress) :) Thank you! 🧡

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>su.nightexpress.excellentcrates</groupId>
     <artifactId>ExcellentCrates</artifactId>
-    <version>6.3.3</version>
+    <version>6.3.4-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>21</maven.compiler.source>

--- a/src/main/java/su/nightexpress/excellentcrates/opening/selectable/SelectableMenu.java
+++ b/src/main/java/su/nightexpress/excellentcrates/opening/selectable/SelectableMenu.java
@@ -36,13 +36,15 @@ import static su.nightexpress.nightcore.util.text.tag.Tags.*;
 
 public class SelectableMenu extends LinkedMenu<CratesPlugin, SelectableOpening> implements ConfigBased, Filled<Reward> {
 
-    private int[]        rewardSlots;
-    private String       rewardName;
-    private List<String> rewardLore;
+    private int[] rewardSlots;
+    private boolean randomizeSlots;
 
+    private String rewardName;
+    private Material rewardMaterial;
+    private List<String> rewardLore;
     private String rewardEntry;
 
-    private NightItem  selectedIcon;
+    private NightItem selectedIcon;
 
     private NightSound selectSound;
     private NightSound unselectSound;
@@ -58,35 +60,39 @@ public class SelectableMenu extends LinkedMenu<CratesPlugin, SelectableOpening> 
     public MenuFiller<Reward> createFiller(@NotNull MenuViewer viewer) {
         Player player = viewer.getPlayer();
         SelectableOpening opening = this.getLink(player);
-        //Crate crate = opening.getCrate();
+
+        List<Reward> items = opening.getDisplayRewards(this.randomizeSlots);
+        int visible = Math.min(items.size(), this.rewardSlots.length);
+        int[] slotsToUse = opening.getDisplaySlots(this.rewardSlots, this.randomizeSlots, visible);
 
         return MenuFiller.builder(this)
-            .setSlots(this.rewardSlots)
-            .setItems(opening.getRewards())
-            .setItemCreator(reward -> {
-                NightItem item = opening.isSelectedReward(reward) ? this.selectedIcon.copy() : NightItem.fromItemStack(reward.getPreviewItem())
-                    .setDisplayName(this.rewardName)
-                    .setLore(this.rewardLore);
-
-                return item.replacement(replacer -> replacer.replace(reward.replacePlaceholders()));
-            })
-            .setItemClick(reward -> (viewer1, event) -> {
-                if (opening.isSelectedReward(reward)) {
-                    opening.removeSelectedReward(reward);
-                    this.unselectSound.play(player);
-                }
-                else {
-                    if (opening.isAllRewardsSelected()) {
-                        this.limitSound.play(player);
-                        return;
+                .setSlots(slotsToUse)
+                .setItems(items)
+                .setItemCreator(reward -> {
+                    NightItem item = opening.isSelectedReward(reward)
+                            ? this.selectedIcon.copy()
+                            : (this.rewardMaterial != null
+                            ? NightItem.fromType(this.rewardMaterial)
+                            : NightItem.fromItemStack(reward.getPreviewItem()))
+                            .setDisplayName(this.rewardName)
+                            .setLore(this.rewardLore);
+                    return item.replacement(r -> r.replace(reward.replacePlaceholders()));
+                })
+                .setItemClick(reward -> (viewer1, event) -> {
+                    if (opening.isSelectedReward(reward)) {
+                        opening.removeSelectedReward(reward);
+                        this.unselectSound.play(player);
+                    } else {
+                        if (opening.isAllRewardsSelected()) {
+                            this.limitSound.play(player);
+                            return;
+                        }
+                        opening.addSelectedReward(reward);
+                        this.selectSound.play(player);
                     }
-
-                    opening.addSelectedReward(reward);
-                    this.selectSound.play(player);
-                }
-                this.runNextTick(() -> this.flush(viewer));
-            })
-            .build();
+                    this.runNextTick(() -> this.flush(viewer));
+                })
+                .build();
     }
 
     @Override
@@ -94,38 +100,31 @@ public class SelectableMenu extends LinkedMenu<CratesPlugin, SelectableOpening> 
     protected String getTitle(@NotNull MenuViewer viewer) {
         Player player = viewer.getPlayer();
         SelectableOpening opening = this.getLink(player);
-
         return Replacer.create()
-            .replace(GENERIC_AMOUNT, () -> String.valueOf(opening.getRequiredAmount()))
-            .replace(GENERIC_CURRENT, () -> String.valueOf(opening.getSelectedAmount()))
-            .apply(super.getTitle(viewer));
+                .replace(GENERIC_AMOUNT, () -> String.valueOf(opening.getRequiredAmount()))
+                .replace(GENERIC_CURRENT, () -> String.valueOf(opening.getSelectedAmount()))
+                .apply(super.getTitle(viewer));
     }
 
     @Override
-    protected void onPrepare(@NotNull MenuViewer viewer, @NotNull InventoryView view) {
-        this.autoFill(viewer);
-    }
+    protected void onPrepare(@NotNull MenuViewer viewer, @NotNull InventoryView view) { this.autoFill(viewer); }
 
     @Override
-    protected void onReady(@NotNull MenuViewer viewer, @NotNull Inventory inventory) {
-
-    }
+    protected void onReady(@NotNull MenuViewer viewer, @NotNull Inventory inventory) {}
 
     @Override
     protected void onItemPrepare(@NotNull MenuViewer viewer, @NotNull MenuItem menuItem, @NotNull NightItem item) {
         super.onItemPrepare(viewer, menuItem, item);
-
         if (!viewer.hasItem(menuItem)) {
             SelectableOpening opening = this.getLink(viewer);
-
             item.replacement(replacer -> replacer
-                .replace(GENERIC_AMOUNT, () -> String.valueOf(opening.getRequiredAmount()))
-                .replace(GENERIC_CURRENT, () -> String.valueOf(opening.getSelectedAmount()))
-                .replace(GENERIC_REWARDS, () -> opening.getSelectedRewards().stream()
-                    .sorted(Comparator.comparing(Reward::getId))
-                    .map(reward -> Replacer.create().replace(reward.replacePlaceholders()).apply(this.rewardEntry))
-                    .collect(Collectors.joining(TAG_LINE_BREAK))
-                )
+                    .replace(GENERIC_AMOUNT, () -> String.valueOf(opening.getRequiredAmount()))
+                    .replace(GENERIC_CURRENT, () -> String.valueOf(opening.getSelectedAmount()))
+                    .replace(GENERIC_REWARDS, () -> opening.getSelectedRewards().stream()
+                            .sorted(Comparator.comparing(Reward::getId))
+                            .map(r -> Replacer.create().replace(r.replacePlaceholders()).apply(this.rewardEntry))
+                            .collect(Collectors.joining(TAG_LINE_BREAK))
+                    )
             );
         }
     }
@@ -134,18 +133,13 @@ public class SelectableMenu extends LinkedMenu<CratesPlugin, SelectableOpening> 
     protected void onClose(@NotNull MenuViewer viewer) {
         SelectableOpening opening = this.getLink(viewer);
         boolean hasAnchor = this.cache.hasAnchor(viewer.getPlayer());
-
         super.onClose(viewer);
-
-        if (!hasAnchor && !opening.isCompleted()) {
-            opening.stop();
-        }
+        if (!hasAnchor && !opening.isCompleted()) opening.stop();
     }
 
     private void handleConfirm(@NotNull MenuViewer viewer) {
         Player player = viewer.getPlayer();
         SelectableOpening opening = this.getLink(player);
-
         opening.confirm();
         this.confirmSound.play(player);
     }
@@ -153,32 +147,24 @@ public class SelectableMenu extends LinkedMenu<CratesPlugin, SelectableOpening> 
     @Override
     public void loadConfiguration(@NotNull FileConfig config, @NotNull MenuLoader loader) {
         this.rewardSlots = ConfigValue.create("Reward.Slots",
-            new int[] {10,11,12,13,14,15,16,19,20,21,22,23,24,25,28,29,30,31,32,33,34}
+                new int[] {10,11,12,13,14,15,16,19,20,21,22,23,24,25,28,29,30,31,32,33,34}
         ).read(config);
+        this.randomizeSlots = ConfigValue.create("Reward.RandomizeSlots", false).read(config);
 
-        this.rewardName = ConfigValue.create("Reward.Name",
-            REWARD_NAME
-        ).read(config);
+        this.rewardName = ConfigValue.create("Reward.Name", REWARD_NAME).read(config);
+        String matStr = ConfigValue.create("Reward.Material", "").read(config);
+        this.rewardMaterial = matStr.isEmpty() ? null : Material.matchMaterial(matStr);
 
         this.rewardLore = ConfigValue.create("Reward.Lore", Lists.newList(
-            REWARD_DESCRIPTION,
-            EMPTY_IF_ABOVE,
-            LIGHT_YELLOW.wrap("→ " + UNDERLINED.wrap("Click to select"))
-        )).read(config);
-
-        this.rewardEntry = ConfigValue.create("Reward.EntryName",
-            GRAY.wrap("- " + REWARD_NAME)
-        ).read(config);
+                REWARD_DESCRIPTION, EMPTY_IF_ABOVE, LIGHT_YELLOW.wrap("→ " + UNDERLINED.wrap("Click to select")
+                ))).read(config);
+        this.rewardEntry = ConfigValue.create("Reward.EntryName", GRAY.wrap("- " + REWARD_NAME)).read(config);
 
         this.selectedIcon = ConfigValue.create("Selection.Icon",
-            NightItem.fromType(Material.LIME_STAINED_GLASS_PANE)
-                .setDisplayName(GREEN.wrap(BOLD.wrap("Selected: ")) + WHITE.wrap(REWARD_NAME))
-                .setLore(Lists.newList(
-                    GRAY.wrap("You'll get this reward."),
-                    "",
-                    GREEN.wrap("→ " + UNDERLINED.wrap("Click to unselect"))
-                ))
-                .hideAllComponents()
+                NightItem.fromType(Material.LIME_STAINED_GLASS_PANE)
+                        .setDisplayName(GREEN.wrap(BOLD.wrap("Selected: ")) + WHITE.wrap(REWARD_NAME))
+                        .setLore(Lists.newList(GRAY.wrap("You'll get this reward."), "", GREEN.wrap("→ " + UNDERLINED.wrap("Click to unselect"))))
+                        .hideAllComponents()
         ).read(config);
 
         this.selectSound = ConfigValue.create("Selection.Sound-V", VanillaSound.of(Sound.BLOCK_NOTE_BLOCK_IRON_XYLOPHONE)).read(config);
@@ -186,46 +172,30 @@ public class SelectableMenu extends LinkedMenu<CratesPlugin, SelectableOpening> 
         this.limitSound = ConfigValue.create("Selection.Sound-Limit", VanillaSound.of(Sound.ENTITY_VILLAGER_NO)).read(config);
         this.confirmSound = ConfigValue.create("Selection.Sound-Confirm", VanillaSound.of(Sound.BLOCK_VAULT_OPEN_SHUTTER)).read(config);
 
-        loader.addDefaultItem(new NightItem(Material.BLACK_STAINED_GLASS_PANE)
-            .setHideTooltip(true)
-            .toMenuItem()
-            .setSlots(IntStream.range(45, 54).toArray())
-        );
-
+        loader.addDefaultItem(new NightItem(Material.BLACK_STAINED_GLASS_PANE).setHideTooltip(true).toMenuItem().setSlots(IntStream.range(45, 54).toArray()));
         loader.addDefaultItem(MenuItem.buildNextPage(this, 53).setPriority(10));
         loader.addDefaultItem(MenuItem.buildPreviousPage(this, 45).setPriority(10));
 
         loader.addDefaultItem(NightItem.fromType(Material.LIME_DYE)
-            .setDisplayName(GREEN.wrap(BOLD.wrap("Confirm")))
-            .setLore(Lists.newList(
-                GRAY.wrap("You'll get the following rewards:"),
-                GENERIC_REWARDS,
-                EMPTY_IF_ABOVE,
-                GREEN.wrap("→ " + UNDERLINED.wrap("Click to confirm"))
-            ))
-            .hideAllComponents()
-            .toMenuItem()
-            .setSlots(49)
-            .setPriority(10)
-            .setHandler(new ItemHandler("confirm", (viewer, event) -> this.handleConfirm(viewer),
-                ItemOptions.builder()
-                    .setVisibilityPolicy(viewer -> this.getLink(viewer).isAllRewardsSelected())
-                    .build()
-            ))
+                .setDisplayName(GREEN.wrap(BOLD.wrap("Confirm")))
+                .setLore(Lists.newList(GRAY.wrap("You'll get the following rewards:"), GENERIC_REWARDS, EMPTY_IF_ABOVE, GREEN.wrap("→ " + UNDERLINED.wrap("Click to confirm"))))
+                .hideAllComponents()
+                .toMenuItem()
+                .setSlots(49)
+                .setPriority(10)
+                .setHandler(new ItemHandler("confirm", (viewer, event) -> this.handleConfirm(viewer),
+                        ItemOptions.builder().setVisibilityPolicy(viewer -> this.getLink(viewer).isAllRewardsSelected()).build()
+                ))
         );
 
         loader.addDefaultItem(NightItem.fromType(Material.GRAY_DYE)
-            .setDisplayName(WHITE.wrap(BOLD.wrap("Confirm")) + " " + GRAY.wrap("(Not Enough)"))
-            .setLore(Lists.newList(
-                GRAY.wrap("You selected " + WHITE.wrap(GENERIC_CURRENT) + "/" + WHITE.wrap(GENERIC_AMOUNT) + " rewards."),
-                "",
-                WHITE.wrap("→ " + UNDERLINED.wrap("Click to exit"))
-            ))
-            .hideAllComponents()
-            .toMenuItem()
-            .setSlots(49)
-            .setPriority(1)
-            .setHandler(ItemHandler.forClose(this))
+                .setDisplayName(WHITE.wrap(BOLD.wrap("Confirm")) + " " + GRAY.wrap("(Not Enough)"))
+                .setLore(Lists.newList(GRAY.wrap("You selected " + WHITE.wrap(GENERIC_CURRENT) + "/" + WHITE.wrap(GENERIC_AMOUNT) + " rewards."), "", WHITE.wrap("→ " + UNDERLINED.wrap("Click to exit"))))
+                .hideAllComponents()
+                .toMenuItem()
+                .setSlots(49)
+                .setPriority(1)
+                .setHandler(ItemHandler.forClose(this))
         );
     }
 }

--- a/src/main/java/su/nightexpress/excellentcrates/opening/selectable/SelectableOpening.java
+++ b/src/main/java/su/nightexpress/excellentcrates/opening/selectable/SelectableOpening.java
@@ -10,25 +10,27 @@ import su.nightexpress.excellentcrates.key.CrateKey;
 import su.nightexpress.excellentcrates.opening.AbstractOpening;
 import su.nightexpress.nightcore.util.random.Rnd;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class SelectableOpening extends AbstractOpening {
 
     protected final SelectableProvider provider;
-    protected final SelectableMenu     menu;
-    protected final Set<Reward>  selectedRewards;
+    protected final SelectableMenu menu;
+    protected final Set<Reward> selectedRewards;
 
     protected boolean confirmed;
     protected boolean completed;
 
+    private int[] displaySlots;
+    private List<Reward> shuffledRewards;
+
     public SelectableOpening(@NotNull CratesPlugin plugin,
-                            @NotNull SelectableProvider provider,
-                            @NotNull SelectableMenu menu,
-                            @NotNull Player player,
-                            @NotNull CrateSource source,
-                            @Nullable CrateKey key) {
+                             @NotNull SelectableProvider provider,
+                             @NotNull SelectableMenu menu,
+                             @NotNull Player player,
+                             @NotNull CrateSource source,
+                             @Nullable CrateKey key) {
         super(plugin, player, source, key);
         this.menu = menu;
         this.provider = provider;
@@ -36,111 +38,118 @@ public class SelectableOpening extends AbstractOpening {
     }
 
     @Override
-    public long getInterval() {
-        return 1L;
-    }
+    public long getInterval() { return 1L; }
 
     @NotNull
-    public List<Reward> getRewards() {
-        return this.crate.getRewards(this.player);
-    }
+    public List<Reward> getRewards() { return this.crate.getRewards(this.player); }
 
-    public int getRequiredAmount() {
-        return Math.min(this.getRewards().size(), this.provider.getSelectionAmount());
-    }
+    public int getRequiredAmount() { return Math.min(this.getRewards().size(), this.provider.getSelectionAmount()); }
 
-    public int getSelectedAmount() {
-        return this.selectedRewards.size();
-    }
+    public int getSelectedAmount() { return this.selectedRewards.size(); }
 
     @NotNull
-    public Set<Reward> getSelectedRewards() {
-        return this.selectedRewards;
-    }
+    public Set<Reward> getSelectedRewards() { return this.selectedRewards; }
 
-    public void addSelectedReward(@NotNull Reward reward) {
-        this.selectedRewards.add(reward);
-    }
+    public void addSelectedReward(@NotNull Reward reward) { this.selectedRewards.add(reward); }
 
-    public void removeSelectedReward(@NotNull Reward reward) {
-        this.selectedRewards.remove(reward);
-    }
+    public void removeSelectedReward(@NotNull Reward reward) { this.selectedRewards.remove(reward); }
 
-    public boolean isSelectedReward(@NotNull Reward reward) {
-        return this.selectedRewards.contains(reward);
-    }
+    public boolean isSelectedReward(@NotNull Reward reward) { return this.selectedRewards.contains(reward); }
 
-    public boolean isAllRewardsSelected() {
-        return this.getSelectedAmount() == this.getRequiredAmount();
-    }
+    public boolean isAllRewardsSelected() { return this.getSelectedAmount() == this.getRequiredAmount(); }
 
     public boolean giveSelectedRewards() {
         if (!this.isAllRewardsSelected()) return false;
-
         this.setRefundable(false);
-
         this.selectedRewards.forEach(reward -> reward.give(this.player));
         this.selectedRewards.clear();
-        this.completed = true; // Use explicit variable to ensure all checks and validations are passed.
+        this.completed = true;
         return true;
     }
 
-    public void confirm() {
-        this.confirmed = true;
-    }
+    public void confirm() { this.confirmed = true; }
 
     @Override
-    protected void onStart() {
-
-    }
+    protected void onStart() {}
 
     @Override
     protected void onTick() {
         if (this.confirmed) {
-            this.confirmed = this.giveSelectedRewards(); // Try give rewards next tick, cancel confirmation if could not.
+            this.confirmed = this.giveSelectedRewards();
             return;
         }
-
-        // Open menu next tick, not on start, because we don't need it in case of (mass-)instant openings.
-        if (!this.menu.isViewer(this.player)) {
-            this.menu.open(this.player, this);
-        }
+        if (!this.menu.isViewer(this.player)) this.menu.open(this.player, this);
     }
 
     @Override
     protected void onStop() {
         super.onStop();
-
-        if (this.menu.isViewer(this.player)) {
-            this.player.closeInventory(); // Let the GUI handle close event properly.
-        }
+        if (this.menu.isViewer(this.player)) this.player.closeInventory();
     }
 
     @Override
-    protected void onComplete() {
-
-    }
+    protected void onComplete() {}
 
     @Override
-    public boolean isCompleted() {
-        return this.completed;
-    }
+    public boolean isCompleted() { return this.completed; }
 
     @Override
     public void instaRoll() {
-        // Just give random rewards I assume?
         List<Reward> rewards = this.getRewards();
         while (!this.isAllRewardsSelected() && !rewards.isEmpty()) {
             Reward reward = rewards.remove(Rnd.get(rewards.size()));
             this.selectedRewards.add(reward);
         }
-
         this.giveSelectedRewards();
         this.stop();
     }
 
     @NotNull
-    public SelectableProvider getProvider() {
-        return this.provider;
+    public SelectableProvider getProvider() { return this.provider; }
+
+    private static List<int[]> rowRuns(int[] base) {
+        List<int[]> runs = new ArrayList<>();
+        int start = 0;
+        for (int i = 1; i <= base.length; i++) {
+            boolean split = (i == base.length);
+            if (!split) {
+                int prev = base[i - 1], cur = base[i];
+                if (cur != prev + 1 || (cur / 9) != (prev / 9)) split = true;
+            }
+            if (split) {
+                runs.add(Arrays.copyOfRange(base, start, i));
+                start = i;
+            }
+        }
+        return runs;
+    }
+
+    public int[] getDisplaySlots(int[] base, boolean randomize, int visibleCount) {
+        if (!randomize) return base;
+        if (this.displaySlots == null) {
+            List<int[]> runs = rowRuns(base);
+            int[] run = runs.isEmpty() ? base : runs.get(0); // first row segment
+            int n = Math.min(visibleCount, run.length);
+
+            int[] block = Arrays.copyOfRange(run, 0, n); // start at first reward slot
+            Set<Integer> used = new HashSet<>();
+            for (int s : block) used.add(s);
+
+            int[] tail = java.util.stream.IntStream.of(base).filter(s -> !used.contains(s)).toArray();
+
+            this.displaySlots = new int[base.length];
+            System.arraycopy(block, 0, this.displaySlots, 0, block.length);
+            System.arraycopy(tail, 0, this.displaySlots, block.length, tail.length);
+        }
+        return this.displaySlots;
+    }
+
+    public List<Reward> getDisplayRewards(boolean randomize) {
+        if (!randomize) return this.getRewards();
+        if (this.shuffledRewards == null) {
+            this.shuffledRewards = new ArrayList<>(this.getRewards());
+            Collections.shuffle(this.shuffledRewards);
+        }
+        return this.shuffledRewards;
     }
 }


### PR DESCRIPTION
Added RandomizeSlots & Material Overrides to Reward for Selectable opening animation.
```yml
Reward:
  RandomizeSlots: true
  Material: 'minecraft:{material}'
```


<img width="522" height="360" alt="image" src="https://github.com/user-attachments/assets/aa20ac23-4c59-462f-b986-4661b6fba131" />
<img width="529" height="361" alt="image" src="https://github.com/user-attachments/assets/0390c4f9-82d0-43ef-ada9-30b8420082e7" />
