### PR TITLE
Redo -  Hidden Rewards for Selectable Opening Animation

### DIFF
--- a/src/main/java/su/nightexpress/excellentcrates/opening/selectable/SelectableMenu.java
+++ b/src/main/java/su/nightexpress/excellentcrates/opening/selectable/SelectableMenu.java
@@ -38,6 +38,7 @@ public class SelectableMenu extends LinkedMenu<CratesPlugin, SelectableOpening> 
 
     private int[]        rewardSlots;
     private String       rewardName;
+    private Material rewardMaterial;
     private List<String> rewardLore;
 
     private String rewardEntry;
@@ -48,6 +49,8 @@ public class SelectableMenu extends LinkedMenu<CratesPlugin, SelectableOpening> 
     private NightSound unselectSound;
     private NightSound limitSound;
     private NightSound confirmSound;
+
+    private boolean randomizeSlots; // Shuffles Rewards when enabled, Tried to make it as least invasive as possible.
 
     public SelectableMenu(@NotNull CratesPlugin plugin) {
         super(plugin, MenuType.GENERIC_9X6, BLACK.wrap("Select " + GENERIC_AMOUNT + " reward(s)!"));
@@ -62,10 +65,12 @@ public class SelectableMenu extends LinkedMenu<CratesPlugin, SelectableOpening> 
 
         return MenuFiller.builder(this)
             .setSlots(this.rewardSlots)
-            .setItems(opening.getRewards())
+            .setItems(opening.getDisplayRewards(this.randomizeSlots))
             .setItemCreator(reward -> {
+                Material overrideMaterial = this.rewardMaterial != null ? this.rewardMaterial : reward.getPreviewItem().getType();
                 NightItem item = opening.isSelectedReward(reward) ? this.selectedIcon.copy() : NightItem.fromItemStack(reward.getPreviewItem())
                     .setDisplayName(this.rewardName)
+                    .setMaterial(overrideMaterial)
                     .setLore(this.rewardLore);
 
                 return item.replacement(replacer -> replacer.replace(reward.replacePlaceholders()));
@@ -159,6 +164,11 @@ public class SelectableMenu extends LinkedMenu<CratesPlugin, SelectableOpening> 
         this.rewardName = ConfigValue.create("Reward.Name",
             REWARD_NAME
         ).read(config);
+
+        String mat = ConfigValue.create("Reward.Material", "").read(config);
+        this.rewardMaterial = mat.isEmpty() ? null : Material.matchMaterial(mat);
+
+        this.randomizeSlots = ConfigValue.create("Reward.RandomizeSlots", false).read(config);
 
         this.rewardLore = ConfigValue.create("Reward.Lore", Lists.newList(
             REWARD_DESCRIPTION,

--- a/src/main/java/su/nightexpress/excellentcrates/opening/selectable/SelectableMenu.java
+++ b/src/main/java/su/nightexpress/excellentcrates/opening/selectable/SelectableMenu.java
@@ -34,12 +34,17 @@ import java.util.stream.IntStream;
 import static su.nightexpress.excellentcrates.Placeholders.*;
 import static su.nightexpress.nightcore.util.text.tag.Tags.*;
 
+/*TODO: Added LockSelection: true/false, LockSelectionRedos: int & Unselect_count lore /w Placeholders.
+  - Modify crate refund logic & reward system that if LockSelection is enabled and any reward is selected and they close it gives the rewards.
+  - Item Name Needs to display actual reward name if selected when LockSelection is enabled.
+*/
 public class SelectableMenu extends LinkedMenu<CratesPlugin, SelectableOpening> implements ConfigBased, Filled<Reward> {
 
     private int[]        rewardSlots;
     private String       rewardName;
-    private Material rewardMaterial;
+    private Material rewardMaterialOverride;
     private List<String> rewardLore;
+    private List<String> selectedRedosCountLore; // Extends Lore when LockSelection is enabled. (There's probably a better way to do this)
 
     private String rewardEntry;
 
@@ -50,7 +55,7 @@ public class SelectableMenu extends LinkedMenu<CratesPlugin, SelectableOpening> 
     private NightSound limitSound;
     private NightSound confirmSound;
 
-    private boolean randomizeSlots; // Shuffles Rewards when enabled, Tried to make it as least invasive as possible.
+    private boolean randomizeSlots; // Shuffles Reward order when enabled, Tried to make it as least invasive as possible.
 
     public SelectableMenu(@NotNull CratesPlugin plugin) {
         super(plugin, MenuType.GENERIC_9X6, BLACK.wrap("Select " + GENERIC_AMOUNT + " reward(s)!"));
@@ -66,30 +71,67 @@ public class SelectableMenu extends LinkedMenu<CratesPlugin, SelectableOpening> 
         return MenuFiller.builder(this)
             .setSlots(this.rewardSlots)
             .setItems(opening.getDisplayRewards(this.randomizeSlots))
-            .setItemCreator(reward -> {
-                Material overrideMaterial = this.rewardMaterial != null ? this.rewardMaterial : reward.getPreviewItem().getType();
-                NightItem item = opening.isSelectedReward(reward) ? this.selectedIcon.copy() : NightItem.fromItemStack(reward.getPreviewItem())
-                    .setDisplayName(this.rewardName)
-                    .setMaterial(overrideMaterial)
-                    .setLore(this.rewardLore);
+                .setItemCreator(reward -> {
+                    boolean selected = opening.isSelectedReward(reward);
+                    boolean locked = opening.getProvider().isLockSelection();
 
-                return item.replacement(replacer -> replacer.replace(reward.replacePlaceholders()));
-            })
+                    if (selected && locked) {
+                        Material originalMat = reward.getPreviewItem().getType();
+                        String originalName = reward.getPreviewItem().hasItemMeta() && reward.getPreviewItem().getItemMeta().hasDisplayName()
+                            ? reward.getPreviewItem().getItemMeta().getDisplayName()
+                            : this.rewardName;
+                        NightItem base = this.selectedIcon.copy();
+                        base.setMaterial(originalMat);
+                        base.setDisplayName(originalName);
+
+                        int max = opening.getProvider().getLockSelectionRedos();
+                        int left = opening.getRedoLeft(reward);
+
+                        if (max > 0 && this.selectedRedosCountLore != null && !this.selectedRedosCountLore.isEmpty()) {
+                            java.util.List<String> lore = new java.util.ArrayList<>();
+                            if (base.getLore() != null) lore.addAll(base.getLore());
+                            for (String line : this.selectedRedosCountLore) {
+                                lore.add(
+                                        line.replace("%redo_used%", String.valueOf(left))
+                                            .replace("%redo_max%", String.valueOf(max))
+                                );
+                            }
+                            base.setLore(lore);
+                        }
+
+                        return base.replacement(r -> r.replace(reward.replacePlaceholders()));
+                    }
+
+                    Material rewardMaterial = (this.rewardMaterialOverride != null && !(opening.isOverrideDisabled(reward)))
+                        ? this.rewardMaterialOverride
+                        : reward.getPreviewItem().getType();
+
+                    NightItem item = selected
+                        ? this.selectedIcon.copy()
+                        : NightItem.fromItemStack(reward.getPreviewItem())
+                        .setDisplayName(this.rewardName)
+                        .setMaterial(rewardMaterial)
+                        .setLore(this.rewardLore);
+
+                    return item.replacement(r -> r.replace(reward.replacePlaceholders()));
+                })
             .setItemClick(reward -> (viewer1, event) -> {
                 if (opening.isSelectedReward(reward)) {
-                    opening.removeSelectedReward(reward);
-                    this.unselectSound.play(player);
-                }
-                else {
+                    boolean ok = opening.tryUnselect(reward);
+                    if (ok) {
+                        this.unselectSound.play(player);
+                    } else {
+                        this.limitSound.play(player);
+                    }
+                } else {
                     if (opening.isAllRewardsSelected()) {
                         this.limitSound.play(player);
                         return;
                     }
-
                     opening.addSelectedReward(reward);
                     this.selectSound.play(player);
                 }
-                this.runNextTick(() -> this.flush(viewer));
+            this.runNextTick(() -> this.flush(viewer));
             })
             .build();
     }
@@ -165,8 +207,8 @@ public class SelectableMenu extends LinkedMenu<CratesPlugin, SelectableOpening> 
             REWARD_NAME
         ).read(config);
 
-        String mat = ConfigValue.create("Reward.Material", "").read(config);
-        this.rewardMaterial = mat.isEmpty() ? null : Material.matchMaterial(mat);
+        String mat = ConfigValue.create("Reward.MaterialOverride", "").read(config);
+        this.rewardMaterialOverride = mat.isEmpty() ? null : Material.matchMaterial(mat);
 
         this.randomizeSlots = ConfigValue.create("Reward.RandomizeSlots", false).read(config);
 
@@ -189,6 +231,11 @@ public class SelectableMenu extends LinkedMenu<CratesPlugin, SelectableOpening> 
                     GREEN.wrap("→ " + UNDERLINED.wrap("Click to unselect"))
                 ))
                 .hideAllComponents()
+        ).read(config);
+
+        this.selectedRedosCountLore = ConfigValue.create(
+                "Selection.Icon.Redos_Count",
+                Lists.newList()
         ).read(config);
 
         this.selectSound = ConfigValue.create("Selection.Sound-V", VanillaSound.of(Sound.BLOCK_NOTE_BLOCK_IRON_XYLOPHONE)).read(config);

--- a/src/main/java/su/nightexpress/excellentcrates/opening/selectable/SelectableOpening.java
+++ b/src/main/java/su/nightexpress/excellentcrates/opening/selectable/SelectableOpening.java
@@ -10,6 +10,8 @@ import su.nightexpress.excellentcrates.key.CrateKey;
 import su.nightexpress.excellentcrates.opening.AbstractOpening;
 import su.nightexpress.nightcore.util.random.Rnd;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -22,6 +24,8 @@ public class SelectableOpening extends AbstractOpening {
 
     protected boolean confirmed;
     protected boolean completed;
+
+    private List<Reward> shuffledRewards;
 
     public SelectableOpening(@NotNull CratesPlugin plugin,
                             @NotNull SelectableProvider provider,
@@ -142,5 +146,17 @@ public class SelectableOpening extends AbstractOpening {
     @NotNull
     public SelectableProvider getProvider() {
         return this.provider;
+    }
+
+    @NotNull
+    public List<Reward> getDisplayRewards(boolean randomizeSlots) {
+        if (!randomizeSlots) {
+            return this.getRewards();
+        }
+        if (this.shuffledRewards == null) {
+            this.shuffledRewards = new ArrayList<>(this.getRewards());
+            Collections.shuffle(this.shuffledRewards);
+        }
+        return this.shuffledRewards;
     }
 }

--- a/src/main/java/su/nightexpress/excellentcrates/opening/selectable/SelectableProvider.java
+++ b/src/main/java/su/nightexpress/excellentcrates/opening/selectable/SelectableProvider.java
@@ -14,6 +14,10 @@ public class SelectableProvider extends AbstractProvider {
 
     private int selectionAmount = 1;
 
+    private boolean lockSelection;
+
+    private int lockSelectionRedos = 0;
+
     private SelectableMenu menu;
 
     public SelectableProvider(@NotNull CratesPlugin plugin, @NotNull String id) {
@@ -23,6 +27,12 @@ public class SelectableProvider extends AbstractProvider {
     @Override
     public void load(@NotNull FileConfig config) {
         this.selectionAmount = ConfigValue.create("Selection.Amount", this.selectionAmount).read(config);
+
+        // Locks selection & displays reward immediately. (Overriding the selected icon & overrides)
+        this.lockSelection = ConfigValue.create("Selection.LockSelection", this.lockSelection).read(config);
+
+        // How many times can a player redo their selection if lock is enabled. (This allows for "rerolling" certain rewards for a better player experience)
+        this.lockSelectionRedos = ConfigValue.create("Selection.LockSelectionRedos", this.lockSelectionRedos).read(config);
 
         this.menu = new SelectableMenu(this.plugin);
         this.menu.load(config);
@@ -40,5 +50,13 @@ public class SelectableProvider extends AbstractProvider {
 
     public void setSelectionAmount(int selectionAmount) {
         this.selectionAmount = selectionAmount;
+    }
+
+    public boolean isLockSelection() {
+        return this.lockSelection;
+    }
+
+    public int getLockSelectionRedos() {
+        return this.lockSelectionRedos;
     }
 }


### PR DESCRIPTION
This is a reattempt of my previous PR before restarting from scratch.

**RandomizeSlots:** Is an easy config option for an animation that shuffles order of rewards w/o negating Slots setting.

**Material:** Allows for overriding the material of the items only in the opening ui. 

Opted out of editing preview icon to keep preview menu split from the opening animation & it's relatively noninvasive. 
IMO this alone will allow for unique menus. Maybe even a specific slot filter to display; like a "free" slot on a bingo sheet 💀
_Lmk your thoughts on this attempt vs the last._

```yml
Reward:
  RandomizeSlots: true
  Material: 'minecraft:{material}'
```
### Preview Ui:
<img width="776" height="356" alt="image" src="https://github.com/user-attachments/assets/896a59c2-fc2e-4f35-a9d8-036c0c719ee9" />

### Opening Ui:
<img width="732" height="353" alt="image" src="https://github.com/user-attachments/assets/85b73d78-205c-405b-9e23-9a43a5d31fee" />
