### PR TITLE
Add config option to disable cost selection UI

### DIFF
--- a/src/main/java/su/nightexpress/excellentcrates/config/Config.java
+++ b/src/main/java/su/nightexpress/excellentcrates/config/Config.java
@@ -176,6 +176,11 @@ public class Config {
         "Available values: [" + Enums.inline(TimeFormatType.class) + "]"
     );
 
+    public static final ConfigValue<Boolean> OPENING_CONFIRM_ENABLED = ConfigValue.create("Crate.Opening.Confirmation.Enabled",
+        true,
+        "Controls whether the Costs GUI is enabled. When disabled, cost is chosen automatically."
+    );
+
     public static final ConfigValue<Boolean> OPENING_CONFIRM_FOR_SINGLE_COST = ConfigValue.create("Crate.Opening.Confirmation.ForSingleCost",
         false,
         "Controls whether the Costs GUI will appear even if there is only cost option available."

--- a/src/main/java/su/nightexpress/excellentcrates/crate/CrateManager.java
+++ b/src/main/java/su/nightexpress/excellentcrates/crate/CrateManager.java
@@ -456,12 +456,12 @@ public class CrateManager extends AbstractManager<CratesPlugin> {
             return;
         }
 
-        if (crate.hasMultipleCosts() || Config.OPENING_CONFIRM_FOR_SINGLE_COST.get()) {
+        if (Config.OPENING_CONFIRM_ENABLED.get() && (crate.hasMultipleCosts() || Config.OPENING_CONFIRM_FOR_SINGLE_COST.get())) {
             this.openCostMenu(player, source);
             return;
         }
 
-        Cost cost = crate.getFirstCost().orElse(null);
+        Cost cost = crate.getAnyCost(player).orElse(null);
 
         if (Config.MASS_OPENING_SNEAK_TO_USE.get() && player.isSneaking()) {
             this.multiOpenCrate(player, source, OpenOptions.empty(), cost, crate.countMaxOpenings(player));


### PR DESCRIPTION
Restores behavior before cost selection UI was implemented.

Defaults to enabled (current behavior), so no change to config is needed.