### PR TITLE
Fix preview roll chances ignoring permission-locked rewards

### DIFF
--- a/src/main/java/su/nightexpress/excellentcrates/api/crate/Reward.java
+++ b/src/main/java/su/nightexpress/excellentcrates/api/crate/Reward.java
@@ -3,6 +3,7 @@ package su.nightexpress.excellentcrates.api.crate;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import su.nightexpress.excellentcrates.crate.impl.Crate;
 import su.nightexpress.excellentcrates.crate.impl.Rarity;
 import su.nightexpress.excellentcrates.crate.limit.LimitValues;
@@ -48,6 +49,8 @@ public interface Reward extends Writeable {
     void give(@NotNull Player player);
 
     double getRollChance();
+
+    double getRollChance(@Nullable Player player);
 
     @NotNull String getId();
 

--- a/src/main/java/su/nightexpress/excellentcrates/crate/impl/Crate.java
+++ b/src/main/java/su/nightexpress/excellentcrates/crate/impl/Crate.java
@@ -820,7 +820,12 @@ public class Crate implements ConfigBacked {
 
     @NotNull
     public Set<Rarity> getRarities() {
-        return this.getRewards().stream().map(Reward::getRarity).collect(Collectors.toSet());
+        return this.getRarities(null);
+    }
+
+    @NotNull
+    public Set<Rarity> getRarities(@Nullable Player player) {
+        return this.getRewards(player, null).stream().map(Reward::getRarity).collect(Collectors.toSet());
     }
 
     @NotNull

--- a/src/main/java/su/nightexpress/excellentcrates/crate/impl/Rarity.java
+++ b/src/main/java/su/nightexpress/excellentcrates/crate/impl/Rarity.java
@@ -1,6 +1,8 @@
 package su.nightexpress.excellentcrates.crate.impl;
 
+import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import su.nightexpress.excellentcrates.CratesPlugin;
 import su.nightexpress.excellentcrates.Placeholders;
 import su.nightexpress.nightcore.config.FileConfig;
@@ -47,7 +49,11 @@ public class Rarity {
     }
 
     public double getRollChance(@NotNull Crate crate) {
-        return this.getRollChance(crate.getRarities());
+        return this.getRollChance(crate, null);
+    }
+
+    public double getRollChance(@NotNull Crate crate, @Nullable Player player) {
+        return this.getRollChance(crate.getRarities(player));
     }
 
     public double getRollChance(@NotNull Collection<Rarity> rarities) {

--- a/src/main/java/su/nightexpress/excellentcrates/crate/menu/PreviewMenu.java
+++ b/src/main/java/su/nightexpress/excellentcrates/crate/menu/PreviewMenu.java
@@ -23,6 +23,7 @@ import su.nightexpress.nightcore.ui.menu.item.ItemOptions;
 import su.nightexpress.nightcore.ui.menu.item.MenuItem;
 import su.nightexpress.nightcore.ui.menu.type.LinkedMenu;
 import su.nightexpress.nightcore.util.Lists;
+import su.nightexpress.nightcore.util.NumberUtil;
 import su.nightexpress.nightcore.util.bukkit.NightItem;
 import su.nightexpress.nightcore.util.placeholder.Replacer;
 
@@ -100,6 +101,10 @@ public class PreviewMenu extends LinkedMenu<CratesPlugin, CrateSource> implement
                 .setLore(this.rewardLore)
                 .replacement(replacer -> {
                         replacer
+                            // Player-aware odds: reflect the rewards actually rollable for THIS player,
+                            // so permission-locked rewards don't skew the previewed percentages.
+                            .replace(REWARD_ROLL_CHANCE, () -> NumberUtil.format(reward.getRollChance(player)))
+                            .replace(REWARD_RARITY_ROLL_CHANCE, () -> NumberUtil.format(reward.getRarity().getRollChance(crate, player)))
                             .replace(GENERIC_LIMITS, limits)
                             .replace(NO_PERMISSION, restrictions)
                             .replace("%win_limit_amount%", limits)

--- a/src/main/java/su/nightexpress/excellentcrates/crate/reward/AbstractReward.java
+++ b/src/main/java/su/nightexpress/excellentcrates/crate/reward/AbstractReward.java
@@ -2,6 +2,7 @@ package su.nightexpress.excellentcrates.crate.reward;
 
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import su.nightexpress.excellentcrates.CratesPlugin;
 import su.nightexpress.excellentcrates.Placeholders;
 import su.nightexpress.excellentcrates.api.crate.Reward;
@@ -199,8 +200,20 @@ public abstract class AbstractReward implements Reward {
 
     @Override
     public double getRollChance() {
-        double sum = this.crate.getRewards(this.rarity).stream().mapToDouble(Reward::getWeight).sum();
-        double rarityChance = this.rarity.getRollChance(this.crate);
+        return this.getRollChance(null);
+    }
+
+    @Override
+    public double getRollChance(@Nullable Player player) {
+        // A player who can't win this reward has a real chance of 0%.
+        if (player != null && !this.canWin(player)) return 0D;
+
+        // Use the reward pool actually available to the player so previewed odds match real odds
+        // (rewards locked behind permissions are excluded from the roll, raising everyone else's chance).
+        double sum = this.crate.getRewards(player, this.rarity).stream().mapToDouble(Reward::getWeight).sum();
+        if (sum <= 0D) return 0D;
+
+        double rarityChance = this.rarity.getRollChance(this.crate, player);
         double chance = (this.weight / sum) * (rarityChance / 100D);
 
         return chance * 100D;


### PR DESCRIPTION
## Problem

Roll chances shown in the crate **preview** are always computed against the *global* reward pool (`getRollChance()` sums weights over `crate.getRewards(rarity)`, ignoring the viewer).

However, the actual roll **excludes rewards a player cannot win** — `Crate.rollReward(player, rarity)` builds its pool from `getRewards(player, rarity)`, which filters by `canWin(player)` (permissions/requirements), at both the rarity and the reward level.

Result: a player **without** permission to a gated reward sees that reward hidden in the preview (`Hide_Unavailable`), while every remaining reward still shows its global percentage. Those percentages no longer sum to 100% and understate the player's real odds, so the preview looks broken.

## Fix

Add a player-aware `getRollChance(@Nullable Player player)` that derives the chance from the pool actually available to that player:

- `Crate#getRarities(@Nullable Player)` — rarities reachable by the player.
- `Rarity#getRollChance(Crate, @Nullable Player)` — rarity chance over the player's reachable rarities.
- `AbstractReward#getRollChance(Player)` — within-rarity weight over the player's winnable rewards; returns `0%` for a reward the player cannot win.
- `PreviewMenu` now fills `%reward_roll_chance%` / `%reward_rarity_roll_chance%` using the viewer.

The existing no-arg `getRollChance()` simply delegates to `getRollChance(null)` (the global pool), so editor/admin displays and any other callers are unchanged.

## Behaviour after the fix

- Player **without** permission: locked reward stays hidden, remaining rewards show their real odds and sum to 100%.
- Player **with** permission: unchanged.
- With `Hide_Unavailable: false`: a locked reward shows `0%` alongside the existing "no access" lore.

## Notes

Compile not run locally (no Maven configured on this machine); changes are additive and were reviewed by hand. The change is behaviorally scoped to the preview — rolling logic is untouched.
